### PR TITLE
初步增加部分 Avatar 来源白名单，以支持开箱即用的 URL 形式 Avatar。

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,86 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'avatars.githubusercontent.com',
+        port: '',
+        pathname: '/u/*',
+      },
+
+      // Tips: 下面的配置都没有经过完整测试，可能会有问题。
+      // Gravatar（允许任意查询参数、深层路径）
+      {
+        protocol: 'https',
+        hostname: 'secure.gravatar.com',
+        port: '',
+        pathname: '/avatar/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'www.gravatar.com',
+        port: '',
+        pathname: '/avatar/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'gravatar.com',
+        port: '',
+        pathname: '/avatar/**',
+      },
+      // Twitter（允许任意查询参数）
+      {
+        protocol: 'https',
+        hostname: 'pbs.twimg.com',
+        port: '',
+        pathname: '/profile_images/*/*',
+      },
+      // Facebook（允许任意查询参数）
+      {
+        protocol: 'https',
+        hostname: 'graph.facebook.com',
+        port: '',
+        pathname: '/**/picture',
+      },
+      // Google 用户头像（允许任意查询参数、任意深度路径）
+      {
+        protocol: 'https',
+        hostname: 'lh3.googleusercontent.com',
+        port: '',
+        pathname: '/**',
+      },
+      // Discord（允许任意查询参数）
+      {
+        protocol: 'https',
+        hostname: 'cdn.discordapp.com',
+        port: '',
+        pathname: '/avatars/*/*',
+      },
+      // Slack（任意子域，任意深度路径）
+      {
+        protocol: 'https',
+        hostname: '**.slack-edge.com',
+        port: '',
+        pathname: '/avatars/**',
+      },
+      // LinkedIn（允许任意查询参数、深层路径）
+      {
+        protocol: 'https',
+        hostname: 'media.licdn.com',
+        port: '',
+        pathname: '/mpr/mpr/**',
+      },
+      // Instagram（多级子域，任意深度路径）
+      {
+        protocol: 'https',
+        hostname: 'instagram.**.fbcdn.net',
+        port: '',
+        pathname: '/**',
+      },
+    ]
+  }
 };
 
 export default nextConfig;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "next.config.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
目前支持了部分主流社交平台的 Next.JS Image 优化图片来源白名单，除了 Github 外都没有经过测试，主要是没啥时间。